### PR TITLE
Allow building on GHC 8.4, expose `free`, drop unneeded dep from example

### DIFF
--- a/examples/monitor.hs
+++ b/examples/monitor.hs
@@ -1,17 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import Prelude as P
-
-import Control.Monad
-import Data.ByteString.Char8 as BC
+import Control.Monad (forever)
+import Control.Concurrent (threadWaitRead)
 
 import System.UDev.Context
 import System.UDev.Device
 import System.UDev.Monitor
-import System.Posix.IO.Select
-import System.Posix.IO.Select.Types
-
 
 dumpDeviceInfo :: Device -> IO ()
 dumpDeviceInfo dev = do
@@ -22,21 +17,16 @@ dumpDeviceInfo dev = do
   print $ getSysnum    dev
   print $ getDevnode    dev
   print $ getAction    dev
-  P.putStrLn $ "device number: " ++ show (getDevnum dev)
+  putStrLn $ "device number: " ++ show (getDevnum dev)
 
 main :: IO ()
-main = do
-  withUDev $ \ udev -> do
-    setLogPriority udev LogDebug
-    setLogger udev defaultLogger
-    monitor <- newFromNetlink udev UDevId
-    enableReceiving monitor
-    fd <- getFd monitor
-    forever $ do
-      res <- select' [fd] [] [] Never
-      case res of
-        Just ([_], [], []) -> do
-          dev <- receiveDevice monitor
-          dumpDeviceInfo dev
-        Nothing -> return ()
-    return ()
+main = withUDev $ \ udev -> do
+  setLogPriority udev LogDebug
+  setLogger udev defaultLogger
+  monitor <- newFromNetlink udev UDevId
+  enableReceiving monitor
+  fd <- getFd monitor
+  forever $ do
+    threadWaitRead fd
+    dev <- receiveDevice monitor
+    dumpDeviceInfo dev

--- a/src/System/UDev.hs
+++ b/src/System/UDev.hs
@@ -16,8 +16,6 @@ module System.UDev
        , module System.UDev.Util
        ) where
 
-import Data.Monoid
-
 import System.UDev.Context
 import System.UDev.Device
 import System.UDev.Enumerate
@@ -26,14 +24,3 @@ import System.UDev.List
 import System.UDev.Monitor
 import System.UDev.Queue
 import System.UDev.Util
-
-
-type Devtype   = ()
-type Tag       = ()
-
-data Filter = Filter (Maybe (Subsystem, Devtype)) (Maybe Tag)
-
-instance Monoid Filter where
-  mempty  = Filter Nothing Nothing
-  Filter sda ta `mappend` Filter sdb tb
-    = Filter (sda `mappend` sdb) (ta `mappend` tb)

--- a/src/System/UDev/Context.hs
+++ b/src/System/UDev/Context.hs
@@ -15,6 +15,7 @@ module System.UDev.Context
          UDev
        , UDevChild (..)
        , newUDev
+       , freeUDev
        , withUDev
 
          -- * Logging
@@ -31,10 +32,11 @@ module System.UDev.Context
        ) where
 
 import Control.Applicative
+import Control.Monad (void)
 import Control.Exception
 import Data.ByteString as BS
 import Data.ByteString.Char8 as BC
-import Foreign
+import Foreign (Ptr, FunPtr)
 import Foreign.C.String
 import Foreign.C.Types
 import Unsafe.Coerce
@@ -51,9 +53,12 @@ foreign import ccall unsafe "udev_new"
 newUDev :: IO UDev
 newUDev = c_new
 
+freeUDev :: UDev -> IO ()
+freeUDev = void . unref
+
 -- | Like 'newUDev' but context will be released at exit.
 withUDev :: (UDev -> IO a) -> IO a
-withUDev = bracket c_new unref
+withUDev = bracket newUDev freeUDev
 
 {-----------------------------------------------------------------------
 --  Logging

--- a/src/System/UDev/Context.hs
+++ b/src/System/UDev/Context.hs
@@ -130,7 +130,7 @@ setLogger udev logger = c_setLogger udev =<< mkLogger (marshLogger logger)
 -- | Default logger will just print @%PRIO %FILE:%LINE:\n%FN: %FORMAT@
 -- to stdout.
 defaultLogger :: Logger
-defaultLogger _ priority file line fn format = do
+defaultLogger _ priority file line fn format =
   BC.putStrLn $ BS.concat
     [ BC.pack (show priority), " "
     , file, ":", BC.pack (show line), ":\n"

--- a/src/System/UDev/Enumerate.hs
+++ b/src/System/UDev/Enumerate.hs
@@ -75,8 +75,8 @@ addMatchSubsystem :: Enumerate -- ^ context
                   -> Subsystem -- ^ filter for a subsystem of the
                                -- device to include in the list
                   -> IO ()     -- ^ can throw exception
-addMatchSubsystem enumerate subsystem = do
-  throwErrnoIfMinus1_ "addMatchSubsystem" $ do
+addMatchSubsystem enumerate subsystem =
+  throwErrnoIfMinus1_ "addMatchSubsystem" $
     useAsCString subsystem $
       c_addMatchSubsystem enumerate
 
@@ -88,8 +88,8 @@ addNoMatchSubsystem :: Enumerate -- ^ context
                     -> Subsystem -- ^ filter for a subsystem of the
                                  -- device to exclude from the list
                     -> IO ()     -- ^ can throw exception
-addNoMatchSubsystem enumerate subsystem = do
-  throwErrnoIfMinus1_ "addNoMatchSubsystem" $ do
+addNoMatchSubsystem enumerate subsystem =
+  throwErrnoIfMinus1_ "addNoMatchSubsystem" $
     useAsCString subsystem $
       c_addNoMatchSubsystem enumerate
 
@@ -109,13 +109,13 @@ addMatchSysattr :: Enumerate      -- ^ context
                                   -- the device to include in the list
                 -> Maybe SysValue -- ^ optional value of the sys attribute
                 -> IO ()          -- ^ can throw exception
-addMatchSysattr enumerate sysattr mvalue = do
-  throwErrnoIf_ (< 0) "addMatchSysattr" $  do
-    useAsCString sysattr $ \ c_sysattr ->  do
+addMatchSysattr enumerate sysattr mvalue =
+  throwErrnoIf_ (< 0) "addMatchSysattr" $
+    useAsCString sysattr $ \ c_sysattr ->
       case mvalue of
         Nothing    -> c_addMatchSysattr enumerate c_sysattr nullPtr
-        Just value -> do
-          useAsCString value $ \ c_value -> do
+        Just value ->
+          useAsCString value $ \ c_value ->
             c_addMatchSysattr enumerate c_sysattr c_value
 
 foreign import ccall unsafe  "udev_enumerate_add_nomatch_sysattr"
@@ -128,13 +128,13 @@ addNoMatchSysattr :: Enumerate  -- ^ context
                   -> Maybe ByteString -- ^ optional value of the sys
                                       -- attribute
                   -> IO ()
-addNoMatchSysattr enumerate sysattr mvalue = do
-  throwErrnoIf_ (< 0) "addNoMatchSysattr" $  do
-    useAsCString sysattr $ \ c_sysattr ->    do
+addNoMatchSysattr enumerate sysattr mvalue =
+  throwErrnoIf_ (< 0) "addNoMatchSysattr" $
+    useAsCString sysattr $ \ c_sysattr ->
       case mvalue of
         Nothing    -> c_addNoMatchSysattr enumerate c_sysattr nullPtr
-        Just value -> do
-          useAsCString value $ \ c_value -> do
+        Just value ->
+          useAsCString value $ \ c_value ->
             c_addNoMatchSysattr enumerate c_sysattr c_value
 
 foreign import ccall unsafe "udev_enumerate_add_match_property"
@@ -146,10 +146,10 @@ addMatchProperty :: Enumerate  -- ^ context
                                -- device to include in the list
                  -> ByteString -- ^ value of the property
                  -> IO ()
-addMatchProperty enumerate prop value = do
-  throwErrnoIf_ (< 0) "addMatchProperty" $ do
-    useAsCString prop $ \ c_prop -> do
-      useAsCString value $ \ c_value -> do
+addMatchProperty enumerate prop value =
+  throwErrnoIf_ (< 0) "addMatchProperty" $
+    useAsCString prop $ \ c_prop ->
+      useAsCString value $ \ c_value ->
         c_addMatchProperty enumerate c_prop c_value
 
 foreign import ccall unsafe "udev_enumerate_add_match_tag"
@@ -161,9 +161,9 @@ addMatchTag :: Enumerate  -- ^ context
             -> ByteString -- ^ filter for a tag of the device to
                           -- include in the list
             -> IO ()
-addMatchTag enumerate tag = do
-  throwErrnoIf_ (< 0) "addMatchTag" $ do
-    useAsCString tag $ \ c_tag -> do
+addMatchTag enumerate tag =
+  throwErrnoIf_ (< 0) "addMatchTag" $
+    useAsCString tag $ \ c_tag ->
       c_addMatchTag enumerate c_tag
 
 foreign import ccall unsafe "udev_enumerate_add_match_parent"
@@ -178,8 +178,8 @@ foreign import ccall unsafe "udev_enumerate_add_match_parent"
 addMatchParent :: Enumerate -- ^ context
                -> Device    -- ^ parent device where to start searching
                -> IO ()     -- ^ can throw exception
-addMatchParent enumerate dev = do
-  throwErrnoIf_ (< 0) "addMatchParent" $ do
+addMatchParent enumerate dev =
+  throwErrnoIf_ (< 0) "addMatchParent" $
     c_addMatchParent enumerate dev
 
 foreign import ccall unsafe "udev_enumerate_add_match_is_initialized"
@@ -187,8 +187,8 @@ foreign import ccall unsafe "udev_enumerate_add_match_is_initialized"
 
 -- | Match only devices which udev has set up already.
 addMatchIsInitialized :: Enumerate -> IO ()
-addMatchIsInitialized enumerate = do
-  throwErrnoIfMinus1_ "addMatchIsInitialized" $ do
+addMatchIsInitialized enumerate =
+  throwErrnoIfMinus1_ "addMatchIsInitialized" $
     c_addMatchIsInitialized enumerate
 
 foreign import ccall unsafe "udev_enumerate_add_match_sysname"
@@ -199,8 +199,8 @@ addMatchSysname :: Enumerate  -- ^ context
                 -> ByteString -- ^ filter for the name of the device
                               -- to include in the list
                 -> IO ()      -- ^ can throw exception
-addMatchSysname enumerate sysName = do
-  throwErrnoIfMinus1_ "addMatchSysname" $ do
+addMatchSysname enumerate sysName =
+  throwErrnoIfMinus1_ "addMatchSysname" $
     useAsCString sysName $
       c_addMatchSysname enumerate
 
@@ -213,9 +213,9 @@ foreign import ccall unsafe "udev_enumerate_add_syspath"
 addSyspath :: Enumerate   -- ^ context
            -> RawFilePath -- ^ path of a device
            -> IO ()       -- ^ can throw exception
-addSyspath enumerate syspath = do
-  throwErrnoIf_ (< 0) "addSyspath" $ do
-    useAsCString syspath $ \ c_syspath -> do
+addSyspath enumerate syspath =
+  throwErrnoIf_ (< 0) "addSyspath" $
+    useAsCString syspath $ \ c_syspath ->
       c_addSyspath enumerate c_syspath
 
 {-----------------------------------------------------------------------

--- a/src/System/UDev/List.hs
+++ b/src/System/UDev/List.hs
@@ -20,10 +20,8 @@ module System.UDev.List
 import Control.Monad
 import Data.ByteString
 import Foreign.C.String
-import Foreign.C.Types
 
 import System.UDev.Types
-
 
 foreign import ccall unsafe "udev_list_entry_get_next"
   c_getNext :: List -> IO List

--- a/src/System/UDev/Monitor.hs
+++ b/src/System/UDev/Monitor.hs
@@ -96,8 +96,8 @@ unmarshalSourceId (OtherId i) = i
 newFromNetlink :: UDev -> SourceId -> IO Monitor
 newFromNetlink udev sid =
   Monitor <$> do
-    throwErrnoIfNull "newFromNetlink" $ do
-      useAsCString (unmarshalSourceId sid) $ \ c_name -> do
+    throwErrnoIfNull "newFromNetlink" $
+      useAsCString (unmarshalSourceId sid) $ \ c_name ->
         getMonitor <$> c_newFromNetlink udev c_name
 
 
@@ -106,8 +106,8 @@ foreign import ccall unsafe "udev_monitor_enable_receiving"
 
 -- | Binds the 'Monitor' socket to the event source.
 enableReceiving :: Monitor -> IO ()
-enableReceiving monitor = do
-  throwErrnoIfMinus1_ "enableReceiving" $ do
+enableReceiving monitor =
+  throwErrnoIfMinus1_ "enableReceiving" $
     c_enableReceiving monitor
 
 foreign import ccall unsafe "udev_monitor_set_receive_buffer_size"
@@ -115,8 +115,8 @@ foreign import ccall unsafe "udev_monitor_set_receive_buffer_size"
 
 -- | Set the size of the kernel socket buffer.
 setReceiveBufferSize :: Monitor -> Int -> IO ()
-setReceiveBufferSize monitor size = do
-  throwErrnoIfMinus1_ "setReceiveBufferSize" $ do
+setReceiveBufferSize monitor size =
+  throwErrnoIfMinus1_ "setReceiveBufferSize" $
     c_setReceiveBufferSize monitor (fromIntegral size)
 
 foreign import ccall unsafe "udev_monitor_get_fd"
@@ -138,10 +138,10 @@ foreign import ccall unsafe "udev_monitor_receive_device"
 -- device, fill in the received data, and return the device.
 --
 receiveDevice :: Monitor -> IO Device
-receiveDevice monitor = do
-  Device <$> do
-    throwErrnoIfNull "receiveDevice" $ do
-      getDevice <$> c_receiveDevice monitor
+receiveDevice monitor =
+  Device <$>
+    throwErrnoIfNull "receiveDevice"
+      (getDevice <$> c_receiveDevice monitor)
 
 foreign import ccall unsafe "udev_monitor_filter_add_match_subsystem_devtype"
   c_filterAddMatchSubsystemDevtype :: Monitor -> CString -> CString -> IO CInt
@@ -152,7 +152,7 @@ foreign import ccall unsafe "udev_monitor_filter_add_match_subsystem_devtype"
 -- listening mode.
 --
 filterAddMatchSubsystemDevtype :: Monitor -> ByteString -> Maybe ByteString -> IO ()
-filterAddMatchSubsystemDevtype monitor subsystem mbDevtype = do
+filterAddMatchSubsystemDevtype monitor subsystem mbDevtype =
   throwErrnoIfMinus1_ "filterAddMatchSubsystemDevtype" $
     useAsCString subsystem $ \ c_subsystem ->
       case mbDevtype of
@@ -169,9 +169,9 @@ foreign import ccall unsafe "udev_monitor_filter_add_match_tag"
 -- listening mode.
 --
 filterAddMatchTag :: Monitor -> ByteString -> IO ()
-filterAddMatchTag monitor tag = do
-  throwErrnoIfMinus1_ "filterAddMatchTag" $ do
-    useAsCString tag $ \ c_tag -> do
+filterAddMatchTag monitor tag =
+  throwErrnoIfMinus1_ "filterAddMatchTag" $
+    useAsCString tag $ \ c_tag ->
       c_filterAddMatchTag monitor c_tag
 
 foreign import ccall unsafe "udev_monitor_filter_update"
@@ -181,8 +181,8 @@ foreign import ccall unsafe "udev_monitor_filter_update"
 -- filter was removed or changed.
 --
 filterUpdate :: Monitor -> IO ()
-filterUpdate monitor = do
-  throwErrnoIfMinus1_ "filterUpdate" $ do
+filterUpdate monitor =
+  throwErrnoIfMinus1_ "filterUpdate" $
     c_filterUpdate monitor
 
 
@@ -191,6 +191,6 @@ foreign import ccall unsafe "udev_monitor_filter_remove"
 
 -- | Remove all filters from monitor.
 filterRemove :: Monitor -> IO ()
-filterRemove monitor = do
-  throwErrnoIfMinus1_ "filterRemove" $ do
+filterRemove monitor =
+  throwErrnoIfMinus1_ "filterRemove" $
     c_filterRemove monitor

--- a/src/System/UDev/Queue.hs
+++ b/src/System/UDev/Queue.hs
@@ -82,7 +82,7 @@ sequenceIsFinished :: Queue   -- ^ udev queue context
                    -> Seqnum  -- ^ last event sequence number
                    -> IO Bool -- ^ if any of the sequence numbers in
                               -- the given range is currently active
-sequenceIsFinished queue start end = do
+sequenceIsFinished queue start end =
   (> 0) <$> c_sequenceIsFinished queue (fromIntegral start)
                                        (fromIntegral end)
 {-# INLINE sequenceIsFinished #-}

--- a/udev.cabal
+++ b/udev.cabal
@@ -67,6 +67,6 @@ executable monitor
   default-language:    Haskell2010
   hs-source-dirs:      examples
   main-is:             monitor.hs
-  build-depends:       base, bytestring, udev, select
+  build-depends:       base, bytestring, udev
   if !flag(examples)
     buildable:         False


### PR DESCRIPTION
* Cleanup monitor example, drop dep on select package. 
  You don't need select to block on a file descriptor, just use `threadWaitRead` (which the GHC runtime will delegate to epoll on Linux).
* Clear up "redundant do" hlint warnings.
* Remove unused (unexported) code that was preventing building on GHC 8.4
* Expose "free" to correspond with "new" for UDev Context
  Currently the only way to "free" is by using `withUDev` (which is limited to `IO`).