### PR TITLE
Fix getDriver crash

### DIFF
--- a/examples/monitor.hs
+++ b/examples/monitor.hs
@@ -17,6 +17,7 @@ dumpDeviceInfo dev = do
   print $ getSysnum    dev
   print $ getDevnode    dev
   print $ getAction    dev
+  print $ getDriver    dev
   putStrLn $ "device number: " ++ show (getDevnum dev)
 
 main :: IO ()

--- a/src/System/UDev/Device.hs
+++ b/src/System/UDev/Device.hs
@@ -324,8 +324,9 @@ foreign import ccall unsafe "udev_device_get_driver"
 
 -- | Get the kernel driver name.
 getDriver :: Device -> ByteString
-getDriver dev = unsafePerformIO $
-  packCString =<< c_getDriver dev
+getDriver dev = unsafePerformIO $ do
+  driver <- c_getDriver dev
+  if driver == nullPtr then return Nothing else Just <$> packCString driver
 
 foreign import ccall unsafe "udev_device_get_devnum"
   c_getDevnum :: Device -> Dev_t


### PR DESCRIPTION
Properly handle a NULL return from udev_device_get_driver.

Change return type of getDriver to Maybe ByteString to account for a missing result.

Add getDriver to the monitor example.

Closes #5.

---

The comment on the udev_device_get_driver C function indicates it can return NULL. I observed this on my system.

https://github.com/systemd/systemd/blob/e6267e832bc8/src/libudev/libudev-device.c#L120
> Returns: the driver name string, or #NULL if there is no driver attached.
